### PR TITLE
Fix ESP32S3 image creation issue

### DIFF
--- a/DFRobot_HumanDetection.cpp
+++ b/DFRobot_HumanDetection.cpp
@@ -12,7 +12,7 @@
 #include "DFRobot_HumanDetection.h"
 #include "stdio.h"
 
-DFRobot_HumanDetection::DFRobot_HumanDetection(Stream *s) : _s(s)
+DFRobot_HumanDetection::DFRobot_HumanDetection(esphome::uart::UARTComponent *s) : _s(s)
 {
 }
 
@@ -45,7 +45,7 @@ uint8_t DFRobot_HumanDetection::configWorkMode(eWorkMode mode)
         {
             cmdBuf[6] = mode;
             cmdBuf[7] = sumData(7, cmdBuf);
-            _s->write(cmdBuf, 10);
+            _s->write_array(cmdBuf, 10);
 
             delay(10000); // Waiting for mode switch to start
 
@@ -806,7 +806,7 @@ uint8_t DFRobot_HumanDetection::getData(uint8_t con, uint8_t cmd, uint16_t len, 
             {
                 _s->read();
             }
-            _s->write(cmdBuf, 9 + len); 
+            _s->write_array(cmdBuf, 9 + len); 
             timeStart1 = millis();
         }
 

--- a/DFRobot_HumanDetection.h
+++ b/DFRobot_HumanDetection.h
@@ -12,6 +12,7 @@
 #ifndef _DFROBOT_HUMAN_DETECTION_
 #define _DFROBOT_HUMAN_DETECTION_
 #include "Arduino.h"
+#include "esphome.h"
 
 #if (defined ARDUINO_AVR_UNO) && (defined ESP8266)
 #include "SoftwareSerial.h"
@@ -225,7 +226,7 @@ public:
      * @brief Constructor of the millimeter-wave human detection sensor
      * @param s Serial reception object
      */
-    DFRobot_HumanDetection(Stream *s);
+    DFRobot_HumanDetection(esphome::uart::UARTComponent *s);
     ~DFRobot_HumanDetection() {};
 
     /**
@@ -496,7 +497,7 @@ private:
      */
     uint8_t getData(uint8_t con, uint8_t cmd, uint16_t len, uint8_t *senData, uint8_t *retData);
     uint8_t sumData(uint8_t len, uint8_t *buf);
-    Stream *_s = NULL;
+    esphome::uart::UARTComponent *_s = NULL;
     sCommandBuffer commandBuffer;
     sResponseBuffer responseBuffer;
 };


### PR DESCRIPTION
Modify `DFRobot_HumanDetection` to accept `UARTComponent` instead of `Stream`.

* **DFRobot_HumanDetection.h**
  - Change constructor to accept `UARTComponent*` instead of `Stream*`.
  - Update private member `_s` to be of type `UARTComponent*`.

* **DFRobot_HumanDetection.cpp**
  - Update constructor to initialize `_s` with `UARTComponent*`.
  - Modify `getData` method to use `UARTComponent` methods instead of `Stream` methods.

