### PR TITLE
Remove global instantiation of `DFRobot_HumanDetection hu` and initia…

### DIFF
--- a/mmwave/mmwave_sensor.cpp
+++ b/mmwave/mmwave_sensor.cpp
@@ -9,8 +9,6 @@ static const char *TAG = "mmwave_sensor.sensor";
 
 #define BAUD_RATE 115200
 
-DFRobot_HumanDetection hu(this);
-
 void MMWaveSensor::setup() {
   Serial.begin(BAUD_RATE);
   
@@ -19,6 +17,8 @@ void MMWaveSensor::setup() {
   #else
   Serial1.begin(BAUD_RATE);
   #endif
+
+  hu = DFRobot_HumanDetection(this);
 
   if (hu.begin() != 0) {
     Serial.println("Sensor initialization failed!");

--- a/mmwave/mmwave_sensor.h
+++ b/mmwave/mmwave_sensor.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
+#include "DFRobot_HumanDetection.h"
 
 namespace esphome {
 namespace mmwave_sensor {
@@ -15,6 +16,9 @@ class MMWaveSensor : public sensor::Sensor, public PollingComponent, public uart
   void dump_config() override;
   void printHumanPresence(int presence);
   void printHumanMovement(int movement);
+
+ private:
+  DFRobot_HumanDetection hu;
 };
 
 }  // namespace mmwave_sensor


### PR DESCRIPTION
…lize it in the `setup` method of the `MMWaveSensor` class.

* Remove the global instantiation of `DFRobot_HumanDetection hu` in `mmwave_sensor.cpp`.
* Initialize `hu` in the `setup` method of the `MMWaveSensor` class with `this`.
* Declare `DFRobot_HumanDetection hu` as a member variable in the `MMWaveSensor` class in `mmwave_sensor.h`.
* Ensure the `MMWaveSensor` class inherits from `uart::UARTDevice` in `mmwave_sensor.h`.