### PR TITLE
Fix incorrect __init__.py definition

### DIFF
--- a/components/mmwave/__init__.py
+++ b/components/mmwave/__init__.py
@@ -1,0 +1,1 @@
+from .sensor import mmwave_sensor


### PR DESCRIPTION
Export the component name `mmwave_sensor` in `components/mmwave/__init__.py`.

* Import `mmwave_sensor` from `sensor.py` in `components/mmwave/__init__.py`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaysalOC3/esphome_ec/pull/10?shareId=fc657ea3-b6f8-470d-9a0d-9cdf69dd7bda).