### PR TITLE
Fix: Add CONFIG_SCHEMA to DFRobot_HumanDetection

### DIFF
--- a/components/DFRobot_HumanDetection/sensor.py
+++ b/components/DFRobot_HumanDetection/sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
 
 DEPENDENCIES = ["uart"]
 
@@ -13,7 +13,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(DFRobot_HumanDetection),
-            cv.Optional("update_interval", default="5s"): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_UPDATE_INTERVAL, default="5s"): cv.positive_time_period_milliseconds,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)

--- a/dfrobot_human_detection.yaml
+++ b/dfrobot_human_detection.yaml
@@ -2,3 +2,4 @@ sensor:
   - platform: "DFRobot_HumanDetection"
     id: human_detection_sensor
     uart_id: uart_bus
+    update_interval: 5s


### PR DESCRIPTION
Add CONFIG_SCHEMA to DFRobot_HumanDetection component to enable loading via YAML.

* Modify `components/DFRobot_HumanDetection/sensor.py` to include `CONFIG_SCHEMA` with necessary parameters.
* Update `dfrobot_human_detection.yaml` to include `CONFIG_SCHEMA` for the `DFRobot_HumanDetection` component.

