### PR TITLE
Refactor presence_sensor_ to Bool type

### DIFF
--- a/components/mmwave/__init__.py
+++ b/components/mmwave/__init__.py
@@ -56,9 +56,9 @@ CONFIG_SCHEMA = (
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_PRESENCE_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_PRESENCE_SENSOR_ID): binary_sensor.BINARY_SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
@@ -157,7 +157,7 @@ async def to_code(config):
     if CONF_PRESENCE_SENSOR_ID in config:
         conf = config[CONF_PRESENCE_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await binary_sensor.register_binary_sensor(sens, conf)
         cg.add(var.set_presence_sensor(sens))
 
     if CONF_SLEEP_STATE_SENSOR_ID in config:

--- a/components/mmwave/mmwave_component.cpp
+++ b/components/mmwave/mmwave_component.cpp
@@ -372,7 +372,7 @@ namespace esphome
                          presence, sleepState, averageRespiration, averageHeartbeat, turnoverNumber, largeBodyMove, minorBodyMove, apneaEvents);
 
                 if (presence_sensor_ != nullptr)
-                    presence_sensor_->publish_state(presence);
+                    presence_sensor_->publish_state(presence == 1);
                 if (sleep_state_sensor_ != nullptr)
                     sleep_state_sensor_->publish_state(sleepState);
                 if (average_respiration_sensor_ != nullptr)

--- a/components/mmwave/mmwave_component.h
+++ b/components/mmwave/mmwave_component.h
@@ -4,6 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/number/number.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include <vector>
 #include <deque> // For storing multiple packets
 
@@ -42,7 +43,7 @@ namespace esphome
             void set_position_sensor(text_sensor::TextSensor *position_sensor) { position_text_sensor_ = position_sensor; }
             void set_movement_sensor(text_sensor::TextSensor *movement_sensor) { movement_sensor_ = movement_sensor; }
 
-            void set_presence_sensor(MMWaveNumber *presence_sensor) { presence_sensor_ = presence_sensor; }
+            void set_presence_sensor(binary_sensor::BinarySensor *presence_sensor) { presence_sensor_ = presence_sensor; }
             void set_sleep_state_sensor(MMWaveNumber *sleep_state_sensor) { sleep_state_sensor_ = sleep_state_sensor; }
             void set_average_respiration_sensor(MMWaveNumber *average_respiration_sensor) { average_respiration_sensor_ = average_respiration_sensor; }
             void set_average_heartbeat_sensor(MMWaveNumber *average_heartbeat_sensor) { average_heartbeat_sensor_ = average_heartbeat_sensor; }
@@ -104,7 +105,7 @@ namespace esphome
             text_sensor::TextSensor *position_text_sensor_{nullptr};
             text_sensor::TextSensor *movement_sensor_{nullptr};
 
-            MMWaveNumber *presence_sensor_{nullptr};
+            binary_sensor::BinarySensor *presence_sensor_{nullptr};
             MMWaveNumber *sleep_state_sensor_{nullptr};
             MMWaveNumber *average_respiration_sensor_{nullptr};
             MMWaveNumber *average_heartbeat_sensor_{nullptr};


### PR DESCRIPTION
Refactor `presence_sensor_` to be a Bool type in the mmwave component.

* **Header File Changes (`components/mmwave/mmwave_component.h`):**
  - Include `binary_sensor/binary_sensor.h`.
  - Update `set_presence_sensor` method to accept `binary_sensor::BinarySensor`.
  - Change `presence_sensor_` type to `binary_sensor::BinarySensor`.

* **Source File Changes (`components/mmwave/mmwave_component.cpp`):**
  - Update `process_sleep_composite` method to use `presence_sensor_` as a `binary_sensor::BinarySensor`.

* **Python File Changes (`components/mmwave/__init__.py`):**
  - Update `CONF_PRESENCE_SENSOR_ID` to be a `binary_sensor.BINARY_SENSOR_SCHEMA`.
  - Register `presence_sensor_` as a `binary_sensor`.

