### PR TITLE
Update mmwave_component to use sensor methods

### DIFF
--- a/components/mmwave/__init__.py
+++ b/components/mmwave/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import uart, text_sensor, binary_sensor, button, number
+from esphome.components import uart, text_sensor, binary_sensor, button, sensor
 from esphome.const import CONF_ID, CONF_NAME, CONF_ON_PRESS
 
 DEPENDENCIES = ["uart"]
@@ -9,7 +9,6 @@ mmwave_component_ns = cg.esphome_ns.namespace("mmwave_ns")
 MMWaveComponent = mmwave_component_ns.class_(
     "MMWaveComponent", cg.Component, uart.UARTDevice
 )
-MMWaveNumber = mmwave_component_ns.class_("MMWaveNumber", number.Number)
 
 CONF_PACKET_TEXT_SENSOR_ID = "packet_text_sensor_id"
 CONF_CONFIG_TEXT_SENSOR_ID = "config_text_sensor_id"
@@ -62,51 +61,51 @@ CONFIG_SCHEMA = (
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_SLEEP_STATE_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_SLEEP_STATE_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_AVERAGE_RESPIRATION_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_AVERAGE_RESPIRATION_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_AVERAGE_RESPIRATION_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_AVERAGE_RESPIRATION_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_AVERAGE_HEARTBEAT_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_AVERAGE_HEARTBEAT_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_TURNOVER_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_TURNOVER_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_LARGE_BODYMOVE_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_LARGE_BODYMOVE_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_MINOR_BODYMOVE_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_MINOR_BODYMOVE_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_APNEA_EVENTS_SENSOR_ID): number.NUMBER_SCHEMA.extend(
+            cv.Optional(CONF_APNEA_EVENTS_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 { 
-                    cv.GenerateID(): cv.declare_id(MMWaveNumber),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
@@ -163,43 +162,43 @@ async def to_code(config):
     if CONF_SLEEP_STATE_SENSOR_ID in config:
         conf = config[CONF_SLEEP_STATE_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_sleep_state_sensor(sens))
 
     if CONF_AVERAGE_RESPIRATION_SENSOR_ID in config:
         conf = config[CONF_AVERAGE_RESPIRATION_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_average_respiration_sensor(sens))
 
     if CONF_AVERAGE_HEARTBEAT_SENSOR_ID in config:
         conf = config[CONF_AVERAGE_HEARTBEAT_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_average_heartbeat_sensor(sens))
 
     if CONF_TURNOVER_SENSOR_ID in config:
         conf = config[CONF_TURNOVER_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_turnover_sensor(sens))
 
     if CONF_LARGE_BODYMOVE_SENSOR_ID in config:
         conf = config[CONF_LARGE_BODYMOVE_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_large_bodymove_sensor(sens))
 
     if CONF_MINOR_BODYMOVE_SENSOR_ID in config:
         conf = config[CONF_MINOR_BODYMOVE_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_minor_bodymove_sensor(sens))
 
     if CONF_APNEA_EVENTS_SENSOR_ID in config:
         conf = config[CONF_APNEA_EVENTS_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await number.register_number(sens, conf, min_value=0, max_value=255, step=1)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_apnea_events_sensor(sens))
 
     if CONF_HUMAN_PRESENCE_SENSOR_ID in config: 

--- a/components/mmwave/mmwave_component.h
+++ b/components/mmwave/mmwave_component.h
@@ -3,7 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/text_sensor/text_sensor.h"
-#include "esphome/components/number/number.h"
+#include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include <vector>
 #include <deque> // For storing multiple packets
@@ -12,17 +12,6 @@ namespace esphome
 {
     namespace mmwave_ns
     {
-        class MMWaveNumber : public number::Number
-        {
-        public:
-            void control(float value) override
-            {
-                // This function is called when the number value is changed from Home Assistant
-                // For most sensor values, we don't need to do anything here since they're read-only
-                this->publish_state(value);
-            }
-        };
-
         class MMWaveComponent : public Component, public uart::UARTDevice
         {
         public:
@@ -44,13 +33,13 @@ namespace esphome
             void set_movement_sensor(text_sensor::TextSensor *movement_sensor) { movement_sensor_ = movement_sensor; }
 
             void set_presence_sensor(binary_sensor::BinarySensor *presence_sensor) { presence_sensor_ = presence_sensor; }
-            void set_sleep_state_sensor(MMWaveNumber *sleep_state_sensor) { sleep_state_sensor_ = sleep_state_sensor; }
-            void set_average_respiration_sensor(MMWaveNumber *average_respiration_sensor) { average_respiration_sensor_ = average_respiration_sensor; }
-            void set_average_heartbeat_sensor(MMWaveNumber *average_heartbeat_sensor) { average_heartbeat_sensor_ = average_heartbeat_sensor; }
-            void set_turnover_sensor(MMWaveNumber *turnover_sensor) { turnover_sensor_ = turnover_sensor; }
-            void set_large_bodymove_sensor(MMWaveNumber *large_bodymove_sensor) { large_bodymove_sensor_ = large_bodymove_sensor; }
-            void set_minor_bodymove_sensor(MMWaveNumber *minor_bodymove_sensor) { minor_bodymove_sensor_ = minor_bodymove_sensor; }
-            void set_apnea_events_sensor(MMWaveNumber *apnea_events_sensor) { apnea_events_sensor_ = apnea_events_sensor; }
+            void set_sleep_state_sensor(sensor::Sensor *sleep_state_sensor) { sleep_state_sensor_ = sleep_state_sensor; }
+            void set_average_respiration_sensor(sensor::Sensor *average_respiration_sensor) { average_respiration_sensor_ = average_respiration_sensor; }
+            void set_average_heartbeat_sensor(sensor::Sensor *average_heartbeat_sensor) { average_heartbeat_sensor_ = average_heartbeat_sensor; }
+            void set_turnover_sensor(sensor::Sensor *turnover_sensor) { turnover_sensor_ = turnover_sensor; }
+            void set_large_bodymove_sensor(sensor::Sensor *large_bodymove_sensor) { large_bodymove_sensor_ = large_bodymove_sensor; }
+            void set_minor_bodymove_sensor(sensor::Sensor *minor_bodymove_sensor) { minor_bodymove_sensor_ = minor_bodymove_sensor; }
+            void set_apnea_events_sensor(sensor::Sensor *apnea_events_sensor) { apnea_events_sensor_ = apnea_events_sensor; }
 
             void set_num_packets_to_store(int num_packets) { num_packets_to_store_ = num_packets; }
 
@@ -106,13 +95,13 @@ namespace esphome
             text_sensor::TextSensor *movement_sensor_{nullptr};
 
             binary_sensor::BinarySensor *presence_sensor_{nullptr};
-            MMWaveNumber *sleep_state_sensor_{nullptr};
-            MMWaveNumber *average_respiration_sensor_{nullptr};
-            MMWaveNumber *average_heartbeat_sensor_{nullptr};
-            MMWaveNumber *turnover_sensor_{nullptr};
-            MMWaveNumber *large_bodymove_sensor_{nullptr};
-            MMWaveNumber *minor_bodymove_sensor_{nullptr};
-            MMWaveNumber *apnea_events_sensor_{nullptr};
+            sensor::Sensor *sleep_state_sensor_{nullptr};
+            sensor::Sensor *average_respiration_sensor_{nullptr};
+            sensor::Sensor *average_heartbeat_sensor_{nullptr};
+            sensor::Sensor *turnover_sensor_{nullptr};
+            sensor::Sensor *large_bodymove_sensor_{nullptr};
+            sensor::Sensor *minor_bodymove_sensor_{nullptr};
+            sensor::Sensor *apnea_events_sensor_{nullptr};
 
             std::deque<std::string> received_packets_;
             int num_packets_to_store_{5}; // Default to storing 5 packets


### PR DESCRIPTION
Update `mmwave_component.h` and `__init__.py` to use `sensor` instead of `number`.

* **mmwave_component.h**
  - Change include from `number.h` to `sensor.h`.
  - Remove `MMWaveNumber` class definition.
  - Update all `MMWaveNumber` member variables to `sensor::Sensor*`.
  - Update all setter methods to use `sensor::Sensor*`.

* **__init__.py**
  - Remove import of `number`.
  - Update schema to use `sensor.SENSOR_SCHEMA` instead of `number.NUMBER_SCHEMA`.
  - Remove `MMWaveNumber` class definition.
  - Update sensor registration to use `sensor` instead of `number`.

