### PR TITLE
Refactor movement_sensor_id to use sensor::Sensor

### DIFF
--- a/components/mmwave/__init__.py
+++ b/components/mmwave/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import uart, text_sensor, binary_sensor, button, number
+from esphome.components import uart, text_sensor, binary_sensor, button, number, sensor
 from esphome.const import CONF_ID, CONF_NAME, CONF_ON_PRESS
 
 DEPENDENCIES = ["uart"]
@@ -50,9 +50,9 @@ CONFIG_SCHEMA = (
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
-            cv.Optional(CONF_MOVEMENT_SENSOR_ID): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            cv.Optional(CONF_MOVEMENT_SENSOR_ID): sensor.SENSOR_SCHEMA.extend(
                 {
-                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.GenerateID(): cv.declare_id(sensor.Sensor),
                     cv.Optional(CONF_NAME): cv.string,
                 }
             ),
@@ -151,7 +151,7 @@ async def to_code(config):
     if CONF_MOVEMENT_SENSOR_ID in config:
         conf = config[CONF_MOVEMENT_SENSOR_ID]
         sens = cg.new_Pvariable(conf[CONF_ID])
-        await text_sensor.register_text_sensor(sens, conf)
+        await sensor.register_sensor(sens, conf)
         cg.add(var.set_movement_sensor(sens))
 
     if CONF_PRESENCE_SENSOR_ID in config:

--- a/components/mmwave/mmwave_component.cpp
+++ b/components/mmwave/mmwave_component.cpp
@@ -340,7 +340,7 @@ namespace esphome
 
             if (movement_sensor_ != nullptr)
             {
-                movement_sensor_->publish_state(std::to_string(data_[6]));
+                movement_sensor_->publish_state(data_[6]);
             }
             else
             {

--- a/components/mmwave/mmwave_component.h
+++ b/components/mmwave/mmwave_component.h
@@ -4,6 +4,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/number/number.h"
+#include "esphome/components/sensor/sensor.h"
 #include <vector>
 #include <deque> // For storing multiple packets
 
@@ -40,7 +41,7 @@ namespace esphome
             void set_packet_text_sensor(text_sensor::TextSensor *packet_sensor) { packet_text_sensor_ = packet_sensor; }
             void set_config_text_sensor(text_sensor::TextSensor *config_sensor) { config_text_sensor_ = config_sensor; }
             void set_position_sensor(text_sensor::TextSensor *position_sensor) { position_text_sensor_ = position_sensor; }
-            void set_movement_sensor(text_sensor::TextSensor *movement_sensor) { movement_sensor_ = movement_sensor; }
+            void set_movement_sensor(sensor::Sensor *movement_sensor) { movement_sensor_ = movement_sensor; }
 
             void set_presence_sensor(MMWaveNumber *presence_sensor) { presence_sensor_ = presence_sensor; }
             void set_sleep_state_sensor(MMWaveNumber *sleep_state_sensor) { sleep_state_sensor_ = sleep_state_sensor; }
@@ -102,7 +103,7 @@ namespace esphome
             text_sensor::TextSensor *packet_text_sensor_{nullptr};
             text_sensor::TextSensor *config_text_sensor_{nullptr};
             text_sensor::TextSensor *position_text_sensor_{nullptr};
-            text_sensor::TextSensor *movement_sensor_{nullptr};
+            sensor::Sensor *movement_sensor_{nullptr};
 
             MMWaveNumber *presence_sensor_{nullptr};
             MMWaveNumber *sleep_state_sensor_{nullptr};


### PR DESCRIPTION
Refactor `movement_sensor_id` to use the standard ESPHome `sensor::Sensor`.

* Update `components/mmwave/__init__.py`:
  - Import `sensor` module.
  - Change `CONF_MOVEMENT_SENSOR_ID` to use `sensor.SENSOR_SCHEMA`.
  - Update `to_code` function to register `movement_sensor_id` as a `sensor`.

* Update `components/mmwave/mmwave_component.h`:
  - Include `sensor/sensor.h`.
  - Change `movement_sensor_` member variable to `sensor::Sensor*`.
  - Update `set_movement_sensor` function to accept `sensor::Sensor*`.

* Update `components/mmwave/mmwave_component.cpp`:
  - Modify `process_movement_data` function to use `sensor::Sensor`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaysalOC3/esphome_ec/pull/17?shareId=a873e339-d73e-4c36-83a6-d68cd446bfb0).